### PR TITLE
Dando suporte a um replica set do mongo

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ Para conectar em um banco remoto exporte a variável de ambiente:
 export POSTMON_DB_HOST=<IP_DO_SERVIDOR>
 ```
 
+Caso você queira se conectar a um replica set do mongo, separe os hosts por *,* (virgulas):
+```bash
+export POSTMON_DB_HOST=<IP_DO_SERVIDOR_1>,<IP_DO_SERVIDOR_2>,...,<IP_DO_SERVIDOR_N>
+```
+
+
 Scheduler
 ---------
 

--- a/database.py
+++ b/database.py
@@ -21,7 +21,7 @@ class MongoDb(object):
 
     def __init__(self):
         DATABASE = os.environ.get('POSTMON_DB_NAME', 'postmon')
-        HOST = os.environ.get('POSTMON_DB_HOST', 'localhost')
+        HOST = os.environ.get('POSTMON_DB_HOST', 'localhost').split(',')
         USERNAME = os.environ.get('POSTMON_DB_USER')
         PASSWORD = os.environ.get('POSTMON_DB_PASSWORD')
 


### PR DESCRIPTION
Segundo a documentação do Pymongo (https://api.mongodb.com/python/2.8/examples/high_availability.html#id1) para realizar a conexão com um replica set, basta passar as replicas como um array.

É possível criar um array com as replicas, porém, parece que não é possível recuperar esse array dentro da aplicação Python (https://stackoverflow.com/a/33829676)